### PR TITLE
Rename Technical Team to Implementation Team

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-teammate-to-team-page.md
+++ b/.github/ISSUE_TEMPLATE/add-teammate-to-team-page.md
@@ -9,6 +9,6 @@ assignees: ''
 
 Submit a pull request with a square jpg representing you (a photo, or an avatar of some sort; recommended resolution 1280x1280) in `img/team` and adding your info to `_data/team.yml` in this repo - that’ll show up (after a little delay) on https://www.distributedgenomics.ca/team.html .
 
-You can copy (say) Matthew Wong's info block in `_data/team.yml` and change `team: alumni` to `team: technical` (along with name, image name, etc).
+You can copy (say) Matthew Wong's info block in `_data/team.yml` and change `team: alumni` to `team: implementation` (along with name, image name, etc).
 
-There's no order to the people in `_data/team.yml` except that we try to keep it in three sections: current technical team members (team: techincal), the PIs (team: leadership), and students, etc. who have moved on (team; alumni)
+There's no order to the people in `_data/team.yml` except that we try to keep it in three sections: current implementation team members (team: implementation), the PIs (team: leadership), and students, etc. who have moved on (team; alumni)

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -1,7 +1,7 @@
 # Team names, titles
 # Note - there's no real order to the names; it started as in order of joining
 # the team but now the only real order is that we try to keep it broken down
-# by "technical", "leadership", "recent_alumni", and "alumni".
+# by "implementation", "leadership", "recent_alumni", and "alumni".
 #
 people:
 - name: Jonathan Dursi
@@ -9,77 +9,77 @@ people:
   firstname: Jonathan
   pic: jonathan_dursi
   position: Technical Lead
-  team: technical
+  team: implementation
 
 - name: Jimmy Li
   lastname: Li
   firstname: Jimmy
   pic: blank
   position: Research Programmer, BCGSC
-  team: technical
+  team: implementation
 
 - name: Dashaylan Naidoo
   lastname: Naidoo
   firstname: Dashaylan
   pic: dashaylan_naidoo
   position: Research Programmer, BCGSC
-  team: technical
+  team: implementation
 
 - name: Felipe Coral-Sasso
   lastname: Coral-Sasso
   firstname: Felipe
   pic: felipe_sasso
   position: Research Programmer, BCGSC
-  team: technical
+  team: implementation
 
 - name: Zhibin Lu
   lastname: Lu
   firstname: Zhibin
   pic: zhibin
   position: Bioinformatics, PMCC
-  team: technical
+  team: implementation
 
 - name: Kat Pavlova
   lastname: Pavlova
   firstname: Kat
   pic: blank
   position: Clin/Pheno Data Models, UHN
-  team: technical
+  team: implementation
 
 - name: Brendan O'Huiginn
   lastname: O'Huiginn
   firstname: Brendan
   pic: brendan_ohuiginn
   position: Systems Administrator, BCGSC
-  team: technical
+  team: implementation
 
 - name: David Bujold
   lastname: Bujold
   firstname: David
   pic: david_bujold
   position: C3G McGill site technical lead
-  team: technical
+  team: implementation
 
 - name: Shaikh Farhan Rashid
   lastname: Rashid
   firstname: Shaikh
   pic: shaikh_rashid
   position: Architecture & Devops, UHN
-  team: technical
+  team: implementation
 
 - name: Samarth Agarwal
   lastname: Agarwal
   firstname: Samarth
   pic: blank
   position: University of Toronto Co-op, UHN
-  team: technical
+  team: implementation
 
 - name: Amanjeev Sethi
   lastname: Sethi
   firstname: Amanjeev
   pic: amanjeev-sethi
   position: Software and Privacy,  UHN
-  team: technical
+  team: implementation
 
 - name: Pierre-Étienne Jacques
   lastname: Jacques

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -1,5 +1,5 @@
 <!-- Team Section -->
-<h3>Technical Team</h3>
+<h3>Implementation</h3>
 <div class="row">
     {% assign technical = site.data.team.people | where:"team","technical" | sort:"lastname"%}
     {% for member in technical %}
@@ -22,7 +22,7 @@
     {% endfor %}
 </div>
 
-<h3>Leadership Team</h3>
+<h3>Leadership</h3>
 <div class="row">
     {% assign leadership = site.data.team.people | where:"team","leadership" | sort:"lastname" %}
     {% for member in leadership %}

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -1,8 +1,8 @@
 <!-- Team Section -->
 <h3>Implementation</h3>
 <div class="row">
-    {% assign technical = site.data.team.people | where:"team","technical" | sort:"lastname"%}
-    {% for member in technical %}
+    {% assign implementation = site.data.team.people | where:"team","implementation" | sort:"lastname"%}
+    {% for member in implementation %}
     <div class="col-sm-4">
         <div class="team-member">
             <img src="img/team/{{ member.pic }}.jpg" class="img-responsive img-circle" alt="">


### PR DESCRIPTION
 Rebrands the technical team as implementation team and changes not only to the data but to the code for semantic alignment with the data.

The reason to do this is to improve the inclusiveness of the team that implements CanDIG which is not limited to technical team members alone. CanDIG recognizes a variety of expertise and talent is needed to achieve its goals. 