### PR TITLE
Fix team page image spacing

### DIFF
--- a/_includes/css/style.css
+++ b/_includes/css/style.css
@@ -1,0 +1,9 @@
+/* CUSTOM CSS */
+.row.display-flex {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .row.display-flex > [class*='col-'] {
+    display: flex;
+    flex-direction: column;
+  }

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -1,6 +1,6 @@
 <!-- Team Section -->
 <h3>Implementation</h3>
-<div class="row">
+<div class="row display-flex">
     {% assign implementation = site.data.team.people | where:"team","implementation" | sort:"lastname"%}
     {% for member in implementation %}
     <div class="col-sm-4">
@@ -23,7 +23,7 @@
 </div>
 
 <h3>Leadership</h3>
-<div class="row">
+<div class="row display-flex">
     {% assign leadership = site.data.team.people | where:"team","leadership" | sort:"lastname" %}
     {% for member in leadership %}
     <div class="col-sm-4">
@@ -48,7 +48,7 @@
 
 <h3>Recent Alumni</h3>
 
-<div class="row">
+<div class="row display-flex">
     {% assign alumni = site.data.team.people | where:"team","recent_alumni" | sort:"lastname" %}
     {% for member in alumni %}
     <div class="col-sm-4">

--- a/_layouts/style.css
+++ b/_layouts/style.css
@@ -1,5 +1,6 @@
 {% include css/bootstrap.min.css %}
 {% include css/agency.css %}
+{% include css/style.css %}
 {{ content }}
 
 


### PR DESCRIPTION
## Problem

Image spacing on the website resulted in team member cards not lining up properly and leaving open white space.

## Why

Bootstrap 3 has a known "height problem" that can occur because of the col-* float-left property when the columns are of different heights. The float left will take it out of the normal flow of the document and it will realign with the next closest container. When the containers are different heights this can result in it hitting another card container before the edge of the container they are within. This is fixed in Bootstrap 4 using a flexbox solution.

[Stackoverflow explanation](https://stackoverflow.com/questions/22310912/bootstrap-row-with-columns-of-different-height)

## Solution

I have implemented the flexbox solution that makes all the columns the same height across each row. This is done by adding custom CSS.

## Before Changes

Here is an example of what the spacing issue could look like at one screen size.

![image](https://user-images.githubusercontent.com/37649170/119165467-5d27d000-ba12-11eb-9aae-11fc6be6dd07.png)

